### PR TITLE
Use personal access tokens when cloning repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bookbinder*.gem
 Gemfile.lock
 .bundle
 file_modification_dates
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 [![Code Climate](https://codeclimate.com/github/pivotal-cf/docs-bookbinder.png)](https://codeclimate.com/github/pivotal-cf/docs-bookbinder) [![Build Status](https://travis-ci.org/cloudfoundry-incubator/bookbinder.png)](https://travis-ci.org/pivotal-cf/docs-bookbinder)
 # Bookbinder
 
+This fork of bookbinder is currently a snowflake for the PCFP team. It inserts basic auth into the template app.
+
 Bookbinder is a gem that binds together a unified documentation web-app from disparate source material, stored as repositories of markdown or plain HTML on GitHub. It runs [middleman](http://middlemanapp.com/) to produce a (CF-pushable) Rackup app.
+
 
 ## About
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Code Climate](https://codeclimate.com/github/pivotal-cf/docs-bookbinder.png)](https://codeclimate.com/github/pivotal-cf/docs-bookbinder) [![Build Status](https://travis-ci.org/cloudfoundry-incubator/bookbinder.png)](https://travis-ci.org/pivotal-cf/docs-bookbinder)
 # Bookbinder
 
-This fork of bookbinder is currently a snowflake for the PCFP team. It inserts basic auth into the template app.
+This fork of bookbinder is currently a snowflake for the PCFP team. It inserts basic auth into the template app. This fork will dissapear when Josh figures out a better way to do this. 
 
 Bookbinder is a gem that binds together a unified documentation web-app from disparate source material, stored as repositories of markdown or plain HTML on GitHub. It runs [middleman](http://middlemanapp.com/) to produce a (CF-pushable) Rackup app.
 

--- a/lib/bookbinder/repository.rb
+++ b/lib/bookbinder/repository.rb
@@ -55,9 +55,19 @@ module Bookbinder
     end
 
     def copy_from_remote(destination_dir, git_accessor = Git)
-      @git = git_accessor.clone("git@github.com:#{full_name}", directory, path: destination_dir)
+      url = get_repo_url(@full_name)
+      @git = git_accessor.clone(url, directory, path: destination_dir)
       @git.checkout(target_ref) unless target_ref == 'master'
       @copied_to = destination_dir
+    end
+    
+    def get_repo_url(name)
+      repo = @github.repository(name)
+      url = repo.rels[:clone].href
+      unless @github.access_token.nil? or @github.access_token.empty?
+        url = url.sub('://', "://#{@github.access_token}:x-oauth-basic@")
+      end
+      url
     end
 
     def copy_from_local(destination_dir)

--- a/spec/bookbinder_helpers_spec.rb
+++ b/spec/bookbinder_helpers_spec.rb
@@ -19,8 +19,11 @@ module Bookbinder
       end
     end
 
+    let(:github) {"https://#{ENV['GITHUB_API_TOKEN']}:x-oauth-basic@github.com"}
+
     before do
       allow(BookbinderLogger).to receive(:new).and_return(logger)
+      allow_any_instance_of(Repository).to receive(:get_repo_url) { |o, name | "#{github}/#{name}"}
     end
 
     def run_middleman(template_variables = {}, subnav_templates = {})

--- a/spec/code_example_spec.rb
+++ b/spec/code_example_spec.rb
@@ -7,6 +7,11 @@ module Bookbinder
       let(:logger) { NilLogger.new }
       let(:git_client) { GitClient.new(logger) }
       let(:code_example) { CodeExample.get_instance(logger, section_hash: {'repository' => {'name' => repo_name}}, git_accessor: SpecGitAccessor) }
+      let(:github) {"https://#{ENV['GITHUB_API_TOKEN']}:x-oauth-basic@github.com"}
+
+      before do
+        allow_any_instance_of(Repository).to receive(:get_repo_url) { |o, name | "#{github}/#{name}"}
+      end
 
       it 'produces a string for the given excerpt_marker' do
         code_snippet = <<-RUBY

--- a/spec/commands/publish_spec.rb
+++ b/spec/commands/publish_spec.rb
@@ -106,6 +106,11 @@ module Bookbinder
 
     context 'github' do
       let(:zipped_repo_url) { "https://github.com/#{book}/archive/master.tar.gz" }
+      let(:github) {"https://#{ENV['GITHUB_API_TOKEN']}:x-oauth-basic@github.com"}
+
+      before do
+        allow_any_instance_of(Repository).to receive(:get_repo_url) { |o, name | "#{github}/#{name}"}
+      end
 
       it 'creates some static HTML' do
         publish_command.run(['github'], SpecGitAccessor)

--- a/spec/credential_provider_spec.rb
+++ b/spec/credential_provider_spec.rb
@@ -3,6 +3,8 @@ require 'spec_helper'
 module Bookbinder
   describe CredentialProvider do
     describe '#credentials' do
+
+
       subject(:credentials) do
         CredentialProvider.new logger, credentials_repository, SpecGitAccessor
       end
@@ -14,6 +16,11 @@ module Bookbinder
       let(:full_name) { 'org-name/creds-repo' }
       let(:credentials_repository) do
         Repository.new(logger: logger, full_name: 'org-name/creds-repo')
+      end
+      let(:github) {"https://#{ENV['GITHUB_API_TOKEN']}:x-oauth-basic@github.com"}
+
+      before do
+        allow_any_instance_of(Repository).to receive(:get_repo_url) { |o, name | "#{github}/#{name}"}
       end
 
       it 'returns a hash of the credentials in credentials.yml' do

--- a/spec/publisher_spec.rb
+++ b/spec/publisher_spec.rb
@@ -12,6 +12,7 @@ module Bookbinder
       let(:non_broken_master_middleman_dir) { generate_middleman_with 'non_broken_index.html' }
       let(:dogs_master_middleman_dir) { generate_middleman_with 'dogs_index.html' }
       let(:git_client) { GitClient.new(logger) }
+      let(:github) {"https://#{ENV['GITHUB_API_TOKEN']}:x-oauth-basic@github.com"}
 
       context 'integration' do
         before do
@@ -19,6 +20,7 @@ module Bookbinder
           allow(BookbinderLogger).to receive(:new).and_return(NilLogger.new)
           allow(ProgressBar).to receive(:create).and_return(double(increment: nil))
           WebMock.disable_net_connect!(:allow_localhost => true)
+          allow_any_instance_of(Repository).to receive(:get_repo_url) { |o, name | "#{github}/#{name}"}
         end
 
         after { WebMock.disable_net_connect! }
@@ -32,11 +34,11 @@ module Bookbinder
           some_sha = 'some-sha'
           some_other_sha = 'some-other-sha'
 
-          expect(SpecGitAccessor).to receive(:clone).with("git@github.com:#{some_repo}",
+          expect(SpecGitAccessor).to receive(:clone).with("#{github}/#{some_repo}",
                                               "pretty_path",
                                               anything).and_call_original
 
-          expect(SpecGitAccessor).to receive(:clone).with("git@github.com:#{some_other_repo}",
+          expect(SpecGitAccessor).to receive(:clone).with("#{github}/#{some_other_repo}",
                                              File.basename(some_other_repo),
                                              anything).and_call_original
           sections = [
@@ -156,10 +158,10 @@ module Bookbinder
           end
 
           it 'applies the syntax highlighting CSS' do
-            expect(SpecGitAccessor).to receive(:clone).with("git@github.com:#{section_repo_name}",
+            expect(SpecGitAccessor).to receive(:clone).with("#{github}/#{section_repo_name}",
                                                             File.basename(section_repo_name),
                                                             anything).and_call_original
-            expect(SpecGitAccessor).to receive(:clone).with("git@github.com:#{code_repo}",
+            expect(SpecGitAccessor).to receive(:clone).with("#{github}/#{code_repo}",
                                                             File.basename(code_repo),
                                                             anything).and_call_original
 
@@ -188,10 +190,10 @@ module Bookbinder
           end
 
           it 'makes only one request per code example repository' do
-            expect(SpecGitAccessor).to receive(:clone).with("git@github.com:org/dogs-repo",
+            expect(SpecGitAccessor).to receive(:clone).with("#{github}/org/dogs-repo",
                                                             "dogs-repo",
                                                             anything).and_call_original
-            expect(SpecGitAccessor).to receive(:clone).with("git@github.com:cloudfoundry/code-example-repo",
+            expect(SpecGitAccessor).to receive(:clone).with("#{github}/cloudfoundry/code-example-repo",
                                                             "code-example-repo",
                                                             anything).and_call_original
 

--- a/spec/repository_url_spec.rb
+++ b/spec/repository_url_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+module Bookbinder
+  describe Repository do
+    include_context 'tmp_dirs'
+
+    describe '#get_repo_url' do
+      let(:logger) { NilLogger.new }
+      let(:github_repo_double) { double Octokit::Repository }
+      let(:git_client) { double GitClient }
+      let(:access_token) { 'foo' }
+
+      class FakeRels
+        def href
+          "https://github.com/org/repo"
+        end
+      end
+
+      before do
+        allow(github_repo_double).to receive(:rels).and_return({clone: FakeRels.new})
+        allow(GitClient).to receive(:new).and_return(git_client)
+        allow(git_client).to receive(:repository).and_return(github_repo_double)
+      end
+
+      context 'if there is an access token' do
+        let(:repo) { Repository.new(logger: logger, full_name: "org/repo", target_ref: "sha",
+                                    github_token: access_token) }
+
+
+        it 'inserts oauth basic user and pass' do
+
+          allow(git_client).to receive(:access_token).and_return(access_token)
+          expect(repo.get_repo_url("org/repo")).to eq("https://foo:x-oauth-basic@github.com/org/repo")
+        end
+      end
+
+      context 'when there is no api token' do
+        let(:repo) { Repository.new(logger: logger, full_name: "org/repo") }
+
+        it 'inserts nothing into the URL' do
+          allow(git_client).to receive(:access_token).and_return(nil)
+          expect(repo.get_repo_url("org/repo")).to eq("https://github.com/org/repo")
+        end
+      end
+    end
+  end
+end

--- a/spec/section_spec.rb
+++ b/spec/section_spec.rb
@@ -7,11 +7,13 @@ module Bookbinder
 
     describe '.get_instance' do
       let(:local_repo_dir) { '/dev/null' }
+      let(:github) {"https://#{ENV['GITHUB_API_TOKEN']}:x-oauth-basic@github.com"}
 
       before do
-        allow(Git).to receive(:clone).with("git@github.com:foo/book",
+        allow(Git).to receive(:clone).with("#{github}/foo/book",
                                             'book',
                                             anything)
+        allow_any_instance_of(Repository).to receive(:get_repo_url) { |o, name | "#{github}/#{name}"}
       end
 
       context 'when called more than once' do

--- a/template_app/config.ru
+++ b/template_app/config.ru
@@ -1,5 +1,9 @@
 require 'vienna'
 
+use Rack::Auth::Basic, 'PCFP Docs' do |username, password|
+    username = 'pcf', password = 'docs'
+end
+
 if File.exists?('redirects.rb')
   require 'rack/rewrite'
   use(Rack::Rewrite) { eval File.read('redirects.rb') }

--- a/template_app/config.ru
+++ b/template_app/config.ru
@@ -1,7 +1,7 @@
 require 'vienna'
 
 use Rack::Auth::Basic, 'PCFP Docs' do |username, password|
-    username = 'pcf', password = 'docs'
+    username == 'pcf' && password == 'docs'
 end
 
 if File.exists?('redirects.rb')


### PR DESCRIPTION
I ran into issues where I could not pull down our private creds repo (docs-pcfp-site-credentials) when I ran <code>bundle exec bookbinder push_local_to_staging</code>. With this change we send the GITHUB_API_TOKEN (personal access key) in the url according to github docs. The clone URI is now assumed to be https instead of git. I'm not sure this is the "right" way to fix this issue, but worked for my needs. It feels weird to change git to https, but there are probably other reasons why that might be good (firewalls), so I didn't sweat it too much. Please advise if I should go about this a different way and I'll take another shot. 

Here's a before and after well as a test run: 

    ➜  docs-book-pcfp git:(master) ✗ bundle exec bookbinder push_local_to_staging                                                                                                                
    Processing pivotal-cf/docs-pcfp-site-credentials
    git clone '--' 'git@github.com:pivotal-cf/docs-pcfp-site-credentials' '/var/folders/44/kxt0zwwx12bb7vkcznnd7_8m0000gp/T/d20141124-8557-1ms722l/docs-pcfp-site-credentials'  2>&1:Cloning into '/var/folders/44/kxt0zwwx12bb7vkcznnd7_8m0000gp/T/d20141124-8557-1ms722l/docs-pcfp-site-credentials'...
    Permission denied (publickey).
    fatal: Could not read from remote repository.

    Please make sure you have the correct access rights and the repository exists.
    ➜  docs-book-pcfp git:(master) ✗ (cd ../bookbinder && git checkout api_tokens )  
    Switched to branch 'api_tokens'

    ➜  docs-book-pcfp git:(master) ✗ bundle exec bookbinder push_local_to_staging  
    Processing pivotal-cf/docs-pcfp-site-credentials
    API endpoint: https://api.run.pivotal.io
    Authenticating...
    OK
    Targeted org pcfp
    ....
    This URL will expire in 2 hours, so if you need to share it, make sure to save a copy now.

    #This is after merging to master, contains changed code
    ➜  bookbinder git:(master) rake
    /Users/jkruck/.rvm/rubies/ruby-2.1.1/bin/ruby -I/Users/jkruck/.rvm/gems/ruby-2.1.1/gems/rspec-core-3.1.7/lib:/Users/jkruck/.rvm/gems/ruby-2.1.1/gems/rspec-support-3.1.2/lib /Users/jkruck/.rvm/gems/ruby-2.1.1/gems/rspec-core-3.1.7/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
    Run options: exclude {:integration=>true}
    .................................................*..................................................................................................................................................................................................................................................................*.........................*....*.............................

    Pending:
      Bookbinder::MiddlemanRunner behaves like a ShellOut
        # Not yet implemented
        # ./spec/middleman_runner_spec.rb:23
      Sieve#links_from when the page is found and it does not have a valid html body
        # No reason given
        # ./spec/sieve_spec.rb:32
      PdfGenerator generates a PDF from the specified pages and header
        # No reason given
        # ./spec/pdf_generator_spec.rb:20
      PdfGenerator when generating pages from a live web-server generates a PDF from a live web-page and header
        # No reason given
        # ./spec/pdf_generator_spec.rb:34

    Finished in 44.2 seconds (files took 1.95 seconds to load)
    369 examples, 0 failures, 4 pending

    Randomized with seed 44177
    
Thanks, 
Josh
