### PR TITLE
Depend on fog-aws, rather than fog.

### DIFF
--- a/bookbinder.gemspec
+++ b/bookbinder.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
   s.executable  = 'bookbinder'
 
-  s.add_runtime_dependency 'fog', ['~> 1.17']
+  s.add_runtime_dependency 'fog-aws', ['~> 0.0.6']
   s.add_runtime_dependency 'octokit', ['2.7.0']
   s.add_runtime_dependency 'ansi', ['~> 1.4']
   s.add_runtime_dependency 'unf', ['~> 0.1']

--- a/lib/bookbinder.rb
+++ b/lib/bookbinder.rb
@@ -1,4 +1,4 @@
-require 'fog'
+require 'fog/aws'
 require 'tmpdir'
 require 'ansi'
 require 'faraday'

--- a/lib/bookbinder/archive.rb
+++ b/lib/bookbinder/archive.rb
@@ -1,4 +1,4 @@
-require 'fog'
+require 'fog/aws'
 require 'tmpdir'
 require_relative 'bookbinder_logger'
 require_relative 'artifact_namer'


### PR DESCRIPTION
This reduces the number of gems required, with minimal code changes.

[#85072126]