### PR TITLE
Extract a command_chain helper

### DIFF
--- a/lib/bookbinder/commands/chain.rb
+++ b/lib/bookbinder/commands/chain.rb
@@ -1,0 +1,11 @@
+module Bookbinder
+  module Commands
+    module Chain
+      private
+
+      def command_chain(*commands)
+        commands.all? {|command| command[] == 0} ? 0 : 1
+      end
+    end
+  end
+end


### PR DESCRIPTION
RunPublishCI is a command made up of other commands. Its success depends
on the subcommands' success. We expect Bind can be broken up like this,
too.