### PR TITLE
Adjust language used when reporting missing config

### DIFF
--- a/lib/bookbinder/configuration_validator.rb
+++ b/lib/bookbinder/configuration_validator.rb
@@ -139,7 +139,9 @@ module Bookbinder
       end
 
       if missing_keys.length > 0
-        raise ConfigurationValidator::MissingRequiredKeyError.new "Your config.yml missing required key. The requires are " + missing_keys.join(", ")
+        raise ConfigurationValidator::MissingRequiredKeyError.new(
+          "Your config.yml is missing required key(s). Required keys are #{missing_keys.join(", ")}."
+        )
       end
     end
   end

--- a/spec/lib/bookbinder/configuration_validator_spec.rb
+++ b/spec/lib/bookbinder/configuration_validator_spec.rb
@@ -23,7 +23,7 @@ module Bookbinder
         end
 
         it 'raises missing key error' do
-          expect { subject.valid? config_hash, bookbinder_schema_version, user_schema_version }.to raise_error ConfigurationValidator::MissingRequiredKeyError, /Your config.yml missing required key. The requires are/
+          expect { subject.valid? config_hash, bookbinder_schema_version, user_schema_version }.to raise_error ConfigurationValidator::MissingRequiredKeyError
         end
       end
 


### PR DESCRIPTION
missing => is missing
key => key(s)
The requires are => Required keys are
 => .

Relax spec so we can change language without duplicating in spec.