### PR TITLE
'bin/bookserver' instead of 'cd final_app; rackup'

### DIFF
--- a/bin/bookserver
+++ b/bin/bookserver
@@ -1,0 +1,3 @@
+#!/usr/bin/env ruby
+
+exec 'bin/rackup -I final_app final_app/config.ru'

--- a/bookbinder.gemspec
+++ b/bookbinder.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.files       = Dir['lib/**/*'] + Dir['template_app/**/*'] + Dir['master_middleman/**/*'] + Dir['bin/**/*']
   s.homepage    = 'https://github.com/cloudfoundry-incubator/bookbinder'
   s.license     = 'MIT'
-  s.executable  = 'bookbinder'
+  s.executables = ['bookbinder', 'bookserver']
 
   s.add_runtime_dependency 'fog-aws', ['~> 0.0.6']
   s.add_runtime_dependency 'octokit', ['2.7.0']

--- a/spec/lib/bookbinder/commands/bind_spec.rb
+++ b/spec/lib/bookbinder/commands/bind_spec.rb
@@ -794,9 +794,9 @@ module Bookbinder
             publish_command.run(['github'])
 
             expect(File.exists?(pre_existing_file)).to eq false
-            copied_manifest = File.read File.join(final_app_dir, 'app.rb')
-            template_manifest = File.read(File.expand_path('../../../../../template_app/app.rb', __FILE__))
-            expect(copied_manifest).to eq(template_manifest)
+            copied_config = File.read File.join(final_app_dir, 'config.ru')
+            template_config = File.read(File.expand_path('../../../../../template_app/config.ru', __FILE__))
+            expect(copied_config).to eq(template_config)
           end
         end
       end

--- a/spec/lib/bookbinder/rack_static_spec.rb
+++ b/spec/lib/bookbinder/rack_static_spec.rb
@@ -1,4 +1,5 @@
-require 'spec_helper'
+require "rack"
+require_relative "../../../template_app/lib/rack_static"
 
 describe Rack::Static do
   let(:index) { 'index.html' }

--- a/spec/lib/bookbinder/vienna_spec.rb
+++ b/spec/lib/bookbinder/vienna_spec.rb
@@ -1,4 +1,5 @@
-require 'spec_helper'
+require "vienna"
+require_relative "../../../template_app/lib/vienna_application"
 
 describe Vienna::Application do
   it 'adds / to paths without them' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,5 @@
 require 'fileutils'
 require_relative '../lib/bookbinder'
-require_relative '../template_app/app.rb'
 require_relative 'fixtures/repo_fixture'
 require_relative 'fixtures/git_object_fixture'
 

--- a/template_app/app.rb
+++ b/template_app/app.rb
@@ -1,2 +1,0 @@
-require_relative 'lib/vienna_application'
-require_relative 'lib/rack_static'

--- a/template_app/app.rb
+++ b/template_app/app.rb
@@ -1,3 +1,2 @@
-exec("rackup -p #{ARGV[0] || 4567}") if require('vienna')
 require_relative 'lib/vienna_application'
 require_relative 'lib/rack_static'

--- a/template_app/config.ru
+++ b/template_app/config.ru
@@ -5,5 +5,7 @@ if File.exists?('redirects.rb')
   use(Rack::Rewrite) { eval File.read('redirects.rb') }
 end
 
-require './app'
+require_relative 'lib/vienna_application'
+require_relative 'lib/rack_static'
+
 run Vienna


### PR DESCRIPTION
Easier to document, less annoying to type.

Also, I'm always confused about whether 'rackup' runs the version specified in my Gemfile or not. This way, we can run from the root dir with a binstub.