### PR TITLE
Remove 'facade' from cloner facade names

### DIFF
--- a/lib/bookbinder/ingest/cloner_factory.rb
+++ b/lib/bookbinder/ingest/cloner_factory.rb
@@ -1,5 +1,5 @@
-require_relative 'git_hub_repository_cloner_facade'
-require_relative 'local_filesystem_cloner_facade'
+require_relative 'git_hub_repository_cloner'
+require_relative 'local_filesystem_cloner'
 
 module Bookbinder
   module Ingest
@@ -11,9 +11,9 @@ module Bookbinder
 
       def produce(source, user_repo_dir)
         if user_repo_dir
-          LocalFilesystemClonerFacade.new(logger, version_control_system, user_repo_dir)
+          LocalFilesystemCloner.new(logger, version_control_system, user_repo_dir)
         else
-          GitHubRepositoryClonerFacade.new(logger, version_control_system)
+          GitHubRepositoryCloner.new(logger, version_control_system)
         end
       end
 

--- a/lib/bookbinder/ingest/git_hub_repository_cloner.rb
+++ b/lib/bookbinder/ingest/git_hub_repository_cloner.rb
@@ -1,6 +1,6 @@
 module Bookbinder
   module Ingest
-    class GitHubRepositoryClonerFacade
+    class GitHubRepositoryCloner
       def initialize(logger, version_control_system)
         @logger = logger
         @version_control_system = version_control_system

--- a/lib/bookbinder/ingest/local_filesystem_cloner.rb
+++ b/lib/bookbinder/ingest/local_filesystem_cloner.rb
@@ -1,6 +1,6 @@
 module Bookbinder
   module Ingest
-    class LocalFilesystemClonerFacade
+    class LocalFilesystemCloner
       def initialize(logger, version_control_system, user_repo_dir)
         @logger = logger
         @version_control_system = version_control_system


### PR DESCRIPTION
I expect we'll eventually implement this interface with the bits from
GHRepo, and it won't be a facade. We don't need the pattern name in the
class / file name.