### PR TITLE
Remove PdfConfig.yml files from fixtures

### DIFF
--- a/spec/fixtures/repositories/book-ref-foo-1.7.12/PdfConfig.yml
+++ b/spec/fixtures/repositories/book-ref-foo-1.7.12/PdfConfig.yml
@@ -1,6 +1,0 @@
----
-header: dogs/index.html
-pages:
-  - some-uri.html
-  - some-other-uri.html
-  - uri-geller.html

--- a/spec/fixtures/repositories/book-ref-v1/PdfConfig.yml
+++ b/spec/fixtures/repositories/book-ref-v1/PdfConfig.yml
@@ -1,6 +1,0 @@
----
-header: dogs/index.html
-pages:
-  - some-uri.html
-  - some-other-uri.html
-  - uri-geller.html

--- a/spec/fixtures/repositories/book-ref-v2/PdfConfig.yml
+++ b/spec/fixtures/repositories/book-ref-v2/PdfConfig.yml
@@ -1,6 +1,0 @@
----
-header: dogs/index.html
-pages:
-  - some-uri.html
-  - some-other-uri.html
-  - uri-geller.html

--- a/spec/fixtures/repositories/book-ref-v3/PdfConfig.yml
+++ b/spec/fixtures/repositories/book-ref-v3/PdfConfig.yml
@@ -1,6 +1,0 @@
----
-header: dogs/index.html
-pages:
-  - some-uri.html
-  - some-other-uri.html
-  - uri-geller.html

--- a/spec/fixtures/repositories/book/PdfConfig.yml
+++ b/spec/fixtures/repositories/book/PdfConfig.yml
@@ -1,6 +1,0 @@
----
-header: dogs/index.html
-pages:
-  - some-uri.html
-  - some-other-uri.html
-  - uri-geller.html

--- a/spec/fixtures/repositories/invalid_config/PdfConfig.yml
+++ b/spec/fixtures/repositories/invalid_config/PdfConfig.yml
@@ -1,6 +1,0 @@
----
-header: dogs/index.html
-pages:
-  - some-uri.html
-  - some-other-uri.html
-  - uri-geller.html


### PR DESCRIPTION
PDF generation is no longer part of Bookbinder.